### PR TITLE
Fix double quote encoding in regex nodes

### DIFF
--- a/net.akehurst.language/agl-processor/build.gradle.kts
+++ b/net.akehurst.language/agl-processor/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("net.akehurst.kotlin.kt2ts") version "1.5.2"
+    id("net.akehurst.kotlin.kt2ts") version "1.5.0"
 }
 
 tasks.withType<ProcessResources>  {

--- a/net.akehurst.language/agl-processor/src/commonMain/kotlin/agl/parser/InputFromCharSequence.kt
+++ b/net.akehurst.language/agl-processor/src/commonMain/kotlin/agl/parser/InputFromCharSequence.kt
@@ -62,7 +62,7 @@ internal class InputFromCharSequence(val text: CharSequence) {
     }
 
     private fun matchRegEx(position: Int, patternText: String): Match? {
-        val pattern = Regex(patternText, setOf(RegexOption.MULTILINE))
+        val pattern = Regex(patternText.replace("\\\"", "\""), setOf(RegexOption.MULTILINE))
         val m = pattern.find(this.text, position)
         val lookingAt = (m?.range?.start == position)
         val matchedText = if (lookingAt) m?.value else null


### PR DESCRIPTION
This patch fixes the handling of escaped double quotes in regular expressions.

For instance:

    MAYBE_QUOTED = "[a-zA-Z_][a-zA-Z0-9_]*|\"[^\"]*\"" ;

Without it, building the grammar fails on an invalid pattern exception, because the escaping hasn't been removed.
